### PR TITLE
fix matuic typos

### DIFF
--- a/app/bundles/LeadBundle/Form/Type/FieldType.php
+++ b/app/bundles/LeadBundle/Form/Type/FieldType.php
@@ -272,13 +272,13 @@ class FieldType extends AbstractType
                 case 'boolean':
                     if (is_array($data)) {
                         $value    = isset($data['defaultValue']) ? $data['defaultValue'] : false;
-                        $yesLabel = !empty($data['properties']['yes']) ? $data['properties']['yes'] : 'matuic.core.form.yes';
-                        $noLabel  = !empty($data['properties']['no']) ? $data['properties']['no'] : 'matuic.core.form.no';
+                        $yesLabel = !empty($data['properties']['yes']) ? $data['properties']['yes'] : 'mautic.core.form.yes';
+                        $noLabel  = !empty($data['properties']['no']) ? $data['properties']['no'] : 'mautic.core.form.no';
                     } else {
                         $value    = $data->getDefaultValue();
                         $props    = $data->getProperties();
-                        $yesLabel = !empty($props['yes']) ? $props['yes'] : 'matuic.core.form.yes';
-                        $noLabel  = !empty($props['no']) ? $props['no'] : 'matuic.core.form.no';
+                        $yesLabel = !empty($props['yes']) ? $props['yes'] : 'mautic.core.form.yes';
+                        $noLabel  = !empty($props['no']) ? $props['no'] : 'mautic.core.form.no';
                     }
 
                     if ($value !== '' && $value !== null) {


### PR DESCRIPTION
Fix typo from "matuic" to "mautic"

[//]: # ( Please answer the following questions: )

| Q  | A
| --- | ---
| Bug fix? | x
| New feature? | 
| Related user documentation PR URL | 
| Related developer documentation PR URL | 
| Issues addressed (#s or URLs) | 
| BC breaks? | 
| Deprecations? | 

[//]: # ( Note that all new features should have a related user and/or developer documentation PR in their respective repositories. )

[//]: # ( Required: )
#### Description: 
Typo could potentially cause a translation problem. I'm not sure if this actually causes any problems, but I just noticed the typo while browsing the code

[//]: # ( As applicable: )
#### Steps to reproduce the bug:
1. 
2. 

#### Steps to test this PR:
1. 
2. 

#### List deprecations along with the new alternative:
1. 
2. 

#### List backwards compatibility breaks:
1. 
2. 